### PR TITLE
fix issue in android action where desired size always ended up as 0

### DIFF
--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -29,7 +29,7 @@ module Fastlane
         params[:appicon_devices].each do |device|
           self.needed_icons[device].each do |scale, sizes|
             sizes.each do |size|
-              width, height = size.split('x').map { |v| v.to_f * scale.to_i }
+              width, height = size.split('x').map { |v| v.to_f }
 
               basepath = Pathname.new("#{params[:appicon_path]}-#{scale}")
               FileUtils.mkdir_p(basepath)


### PR DESCRIPTION
Interpreting 'ldpi' (and the rest) as an integer results in a desired size of 0x0.

That explains all the `gm mogrify: unable to resize image (Non-zero width and height required)` errors I've been getting when trying to use this.