### PR TITLE
Refactoring targeting performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Gemfile.lock
 /rdoc/
 fastlane/README.md
 fastlane/report.xml
+.DS_Store
 
 ## Ignore generated asset catalogue
 Assets.xcassets/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ fastlane/report.xml
 
 ## Ignore generated asset catalogue
 Assets.xcassets/
+
+## Ignore android generated icon
+app/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,14 +12,14 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
 # HoundCI doesn't like this rule
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # We allow !! as it's an easy way to convert ot boolean
@@ -127,7 +127,7 @@ Style/PerlBackrefs:
   Enabled: false
 
 # Disable '+ should be surrounded with a single space' for xcodebuild_spec.rb
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Exclude:
     - '**/spec/actions_specs/xcodebuild_spec.rb'
 

--- a/lib/fastlane/plugin/appicon.rb
+++ b/lib/fastlane/plugin/appicon.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Appicon
     # Return all .rb files inside the "actions" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -22,25 +22,22 @@ module Fastlane
         require 'mini_magick'
         image = MiniMagick::Image.open(fname)
 
-        UI.user_error!("Minimum width of input image should be 512") if image.width < 512
-        UI.user_error!("Minimum height of input image should be 512") if image.height < 512
-        UI.user_error!("Input image should be square") if image.width != image.height
+        Helper::AppiconHelper.check_input_image_size(image, 512)
 
-        params[:appicon_devices].each do |device|
-          self.needed_icons[device].each do |scale, sizes|
-            sizes.each do |size|
-              width, height = size.split('x').map { |v| v.to_f }
+        # Convert image to png
+        image.format 'png'
 
-              basepath = Pathname.new("#{params[:appicon_path]}-#{scale}")
-              FileUtils.mkdir_p(basepath)
-              filename = "#{params[:appicon_filename]}.png"
+        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons)
+        icons.each do |icon|
+          width = icon['width']
+          height = icon['height']
 
-              image = MiniMagick::Image.open(fname)
-              image.format 'png'
-              image.resize "#{width}x#{height}"
-              image.write basepath + filename
-            end
-          end
+          basepath = Pathname.new("#{params[:appicon_path]}-#{icon['scale']}")
+          FileUtils.mkdir_p(basepath)
+          filename = "#{params[:appicon_filename]}.png"
+
+          image.resize "#{width}x#{height}"
+          image.write basepath + filename
         end
 
         UI.success("Successfully stored launcher icons at '#{params[:appicon_path]}'")

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -27,7 +27,7 @@ module Fastlane
         # Convert image to png
         image.format 'png'
 
-        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons)
+        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons, true)
         icons.each do |icon|
           width = icon['width']
           height = icon['height']

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -22,9 +22,7 @@ module Fastlane
         require 'mini_magick'
         image = MiniMagick::Image.open(fname)
 
-        UI.user_error!("Minimum width of input image should be 1024") if image.width < 1024
-        UI.user_error!("Minimum height of input image should be 1024") if image.height < 1024
-        UI.user_error!("Input image should be square") if image.width != image.height
+        Helper::AppiconHelper.check_input_image_size(image, 1024)
 
         # Convert image to png
         image.format 'png'
@@ -32,30 +30,12 @@ module Fastlane
         # Create the base path
         FileUtils.mkdir_p(basepath)
 
-        # Add all needed sizes to the icons pack
-        icons = []
-        params[:appicon_devices].each do |device|
-          self.needed_icons[device].each do |scale, sizes|
-            sizes.each do |size|
-              width, height = size.split('x').map { |v| v.to_f * scale.to_i }
-              icons << {
-                'width' => width,
-                'height' => height,
-                'size' => size,
-                'device' => device,
-                'scale' => scale
-              }
-            end
-          end
-        end
-
         images = []
 
-        # Sort from the largest to the smallest needed icon
-        icons = icons.sort_by {|value| value['width']} .reverse
+        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons)
         icons.each do |icon|
-          width = icon['width']
-          height = icon['height']
+          width = icon['width'].to_f * icon['scale'].to_i
+          height = icon['height'].to_f * icon['scale'].to_i
           filename = "#{basename}-#{width.to_i}x#{height.to_i}.png"
 
           # downsize icon

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -32,10 +32,10 @@ module Fastlane
 
         images = []
 
-        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons)
+        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons, false)
         icons.each do |icon|
-          width = icon['width'].to_f * icon['scale'].to_i
-          height = icon['height'].to_f * icon['scale'].to_i
+          width = icon['width']
+          height = icon['height']
           filename = "#{basename}-#{width.to_i}x#{height.to_i}.png"
 
           # downsize icon

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -1,0 +1,30 @@
+module Fastlane
+  module Helper
+    class AppiconHelper
+      def self.check_input_image_size(image, size)
+        UI.user_error!("Minimum width of input image should be #{size}") if image.width < size
+        UI.user_error!("Minimum height of input image should be #{size}") if image.height < size
+        UI.user_error!("Input image should be square") if image.width != image.height
+      end
+      def self.get_needed_icons(devices, needed_icons)
+        icons = []
+        devices.each do |device|
+          needed_icons[device].each do |scale, sizes|
+            sizes.each do |size|
+              width, height = size.split('x')
+              icons << {
+                'width' => width,
+                'height' => height,
+                'size' => size,
+                'device' => device,
+                'scale' => scale
+              }
+            end
+          end
+        end
+        # Sort from the largest to the smallest needed icon
+        icons = icons.sort_by {|value| value['width']} .reverse
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -6,12 +6,17 @@ module Fastlane
         UI.user_error!("Minimum height of input image should be #{size}") if image.height < size
         UI.user_error!("Input image should be square") if image.width != image.height
       end
-      def self.get_needed_icons(devices, needed_icons)
+      def self.get_needed_icons(devices, needed_icons, is_android = false)
         icons = []
         devices.each do |device|
           needed_icons[device].each do |scale, sizes|
             sizes.each do |size|
-              width, height = size.split('x')
+              if is_android
+                width, height = size.split('x').map { |v| v.to_f }
+              else
+                width, height = size.split('x').map { |v| v.to_f * scale.to_i }
+              end
+
               icons << {
                 'width' => width,
                 'height' => height,


### PR DESCRIPTION
Making a long story short, this PR makes appicon plugin up to 10x faster. 

I've used Appicon and ImageMagick a lot during the last months and always wondered why would appicon action be the one taking more time in my lanes (between 6 and 12 seconds in my tests). 

As I'm using a lot of ImageMagick in other projects I did realize while reading the AppIcon code that it was opening the source image all the time it would resize.

A simple trick to maintain quality while reducing memory usage and thus processing time is to sort the needed icons by size from the largest to the smallest and not reopen the image, only resize from one to the other. 

I did many tests using it to guarantee that quality and result would remain the same. 

I also did some performance check using the provided test icon:

**5 test results using the old code**
1. 7.262053
2. 7.273785
3. 7.5713
4. 6.976845
5. 6.770553

average = **7.1709072 seconds**

**5 test results using the new code**
1. 0.834892
2. 0.820401
3. 0.812199
4. 0.81866
5. 0.788127

average = **0.8148558 seconds**

Minor improvements:  
 - Added some files to .gitignore
 - Added a helper class to reduce code duplication
 - Updated Rubocop settings