### PR TITLE
Don't write change/created times into the PNG properties

### DIFF
--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -43,6 +43,11 @@ module Fastlane
 
           # downsize icon
           image.resize "#{width}x#{height}"
+
+          # Don't write change/created times into the PNG properties
+          # so unchanged files don't have different hashes.
+          image.define("png:exclude-chunks=date,time")
+
           image.write basepath + filename
 
           images << {


### PR DESCRIPTION
..so unchanged files don't have different hashes.

This is a superficial fix for #19 - I suspect ImageMagic is going to generate different output on different machines, but this at least stops it generating different local files on every single run of the plugin.