### PR TITLE
use ios-marketing in contents.json

### DIFF
--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -21,7 +21,7 @@ module Fastlane
                 'width' => width,
                 'height' => height,
                 'size' => size,
-                'device' => device,
+                'device' => device.to_s.gsub('_','-'),
                 'scale' => scale
               }
             end


### PR DESCRIPTION
Not much of a Ruby guy, so let me know if this is bad form. Uses a simple string substitution to output '-' instead of '_' for ios-marketing. This would also affect other symbols that use _, for better or worse.

This should address issue #18 
