### PR TITLE
android_appicon - notification icons and custom sizes

### DIFF
--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -18,6 +18,7 @@ module Fastlane
 
       def self.run(params)
         fname = params[:appicon_image_file]
+        custom_sizes = params[:custom_sizes]
 
         require 'mini_magick'
         image = MiniMagick::Image.open(fname)
@@ -39,8 +40,28 @@ module Fastlane
           image.resize "#{width}x#{height}"
           image.write basepath + filename
         end
+        
+        
 
         UI.success("Successfully stored launcher icons at '#{params[:appicon_path]}'")
+      end
+      
+      def self.get_custom_sizes(custom_sizes)
+        custom_sizes.each do |size|
+          if is_android
+            width, height = size.split('x').map { |v| v.to_f }
+          else
+            width, height = size.split('x').map { |v| v.to_f * scale.to_i }
+          end
+
+          icons << {
+            'width' => width,
+            'height' => height,
+            'size' => size,
+            'device' => device,
+            'scale' => scale
+          }
+        end
       end
 
       def self.description
@@ -75,7 +96,11 @@ module Fastlane
                              default_value: 'ic_launcher',
                                description: "The output filename of each image",
                                   optional: true,
-                                      type: String)
+                                      type: String),
+          FastlaneCore::ConfigItem.new(key: :custom_sizes,
+                               description: "Array of custom sizes",
+                                  optional: true,
+                                      type: Array)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -118,7 +118,7 @@ module Fastlane
                                   optional: true,
                                       type: String),
           FastlaneCore::ConfigItem.new(key: :appicon_custom_sizes,
-                               description: "Hash of custom sizes",
+                               description: "Hash of custom sizes - {'path/icon.png' => '256x256'}",
                                   optional: true,
                                       type: Hash)
         ]

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -7,7 +7,7 @@ module Fastlane
         UI.user_error!("Input image should be square") if image.width != image.height
       end
 
-      def self.get_needed_icons(devices, needed_icons, is_android = false)
+      def self.get_needed_icons(devices, needed_icons, is_android = false, custom_sizes = {})
         icons = []
         devices.each do |device|
           needed_icons[device].each do |scale, sizes|
@@ -35,6 +35,21 @@ module Fastlane
             end
           end
         end
+        
+        # Add custom icon sizes (probably for notifications) 
+        custom_sizes.each do |path, size|
+          path = path.to_s
+          width, height = size.split('x').map { |v| v.to_f }
+
+          icons << {
+            'width' => width,
+            'height' => height,
+            'size' => size,
+            'basepath' => File.dirname(path),
+            'filename' => File.basename(path)
+          }
+        end
+        
         # Sort from the largest to the smallest needed icon
         icons = icons.sort_by {|value| value['width']} .reverse
       end


### PR DESCRIPTION
## Reason
- Android can have separate icons for notification icon (like one signal)
  - Can have different name and different path
- Also needed to do custom icon resizing for a super special large icon for one signal (256x256)

## Example usage
```rb
android_appicon(
  appicon_image_file: "android/icon.png",
  appicon_devices: [:phone, :tablet],
  appicon_path: "android/app/src/main/res/mipmap",

  # Path and name to use for icon resizes
  appicon_notification_icon_path: "android/app/src/main/res/drawable",
  appicon_notification_icon_filename: "ic_stat_onesignal_default.png",

  # Custom map of sizes
  appicon_custom_sizes: {
    "#{drawable_path}-xxxhdpi/ic_onesignal_large_icon_default.png": "256x256"
  }
)
```