### PR TITLE
writes pretty json to content.json file

### DIFF
--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -84,7 +84,7 @@ module Fastlane
         }
 
         require 'json'
-        File.write(File.join(basepath, 'Contents.json'), JSON.dump(contents))
+        File.write(File.join(basepath, 'Contents.json'), JSON.pretty_generate(contents))
         UI.success("Successfully stored app icon at '#{basepath}'")
       end
 


### PR DESCRIPTION
Currently the content of `contents.json` file is a json in single line. This PR makes it prettier and writes the json in proper format.