### PR TITLE
fix `No such file or directory` error for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ end
 
 lane :android do
   android_appicon(
-    appicon_image_file: 'spec/fixtures/Themoji.png',
+    appicon_image_file: 'fastlane/spec/fixtures/Themoji.png',
     appicon_icon_types: [:launcher],
     appicon_path: 'app/res/mipmap'
   )
   android_appicon(
-    appicon_image_file: 'spec/fixtures/ThemojiNotification.png',
+    appicon_image_file: 'fastlane/spec/fixtures/ThemojiNotification.png',
     appicon_icon_types: [:notification],
     appicon_path: 'app/res/drawable',
     appicon_filename: 'ic_notification'


### PR DESCRIPTION
I was running some issue with the path following the instructions on the `README`

<img width="906" alt="image" src="https://user-images.githubusercontent.com/360936/54836810-e4efe380-4cbc-11e9-800c-9b8c01e6d240.png">
