### PR TITLE
#6: Added support for creating Messages extension app icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Just specify the source image using the `appicon_image_file`. Optionally specify
 
 We recommend storing the full-size picture at `fastlane/metadata/app_icon.png` so it can be picked up by _deliver_, as well as this plugin.
 
-If you want to use this plugin to generate a app icon for Messages(sticker) extension, set `messages_extension` to true and add `messages` to the `appicon_devices`.
+If you want to use this plugin to generate a app icon for Messages(sticker) extension, set `messages_extension` to `true` and add `messages` to the `appicon_devices`.
 
 ```ruby
 lane :basic do

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plu
 
 Just specify the source image using the `appicon_image_file`. Optionally specify the devices using `appicon_devices` and the destination path using `appicon_path`.
 
-We recommend storing the full-size picture at `fastlane/metadata/app_icon.png` so it can be picked up by _deliver_, as well as this plugin
+We recommend storing the full-size picture at `fastlane/metadata/app_icon.png` so it can be picked up by _deliver_, as well as this plugin.
+
+If you want to use this plugin to generate a app icon for Messages(sticker) extension, set `messages_extension` to true and add `messages` to the `appicon_devices`.
 
 ```ruby
 lane :basic do
@@ -65,6 +67,15 @@ lane :splash_screen do
     appicon_devices: [:universal],
     appicon_path: "ios/App/App/Assets.xcassets",
     appicon_name: 'Splash.imageset'
+  )
+end
+
+lane :messages_extension do
+  appicon(
+    appicon_image_file: "fastlane/metadata/iMessageAppIcon.png",
+    appicon_devices: [:iphone, :ipad, :ios_marketing, :messages],
+    appicon_path: 'iMessageStickers/Stickers.xcassets',
+    messages_extension: true
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,15 @@ lane :ios_splash do
   )
 end
 
+lane :ios_messages_extension do
+  appicon(
+    appicon_image_file: 'spec/fixtures/ThemojiSplash.png',
+    appicon_devices: [:iphone, :ipad, :ios_marketing, :messages],
+    appicon_path: 'app/iMessageStickers/Stickers.xcassets',
+    messages_extension: true
+  )
+end
+
 lane :android do
   android_appicon(
     appicon_image_file: 'spec/fixtures/Themoji.png',

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -49,7 +49,7 @@ module Fastlane
         icons.each do |icon|
           image = MiniMagick::Image.open(fname)
 
-          Helper::AppiconHelper.check_input_image_size(image, 1024)
+          Helper::AppiconHelper.check_input_image_size(image, 1024, 1024)
 
           # Custom icons will have basepath and filename already defined
           if icon.has_key?('basepath') && icon.has_key?('filename')

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -64,6 +64,7 @@ module Fastlane
       def self.run(params)
         fname = params[:appicon_image_file]
         basename = File.basename(fname, File.extname(fname))
+
         is_messages_extension = params[:messages_extension]
         basepath = Pathname.new(File.join(params[:appicon_path], is_messages_extension ? params[:appicon_messages_name] : params[:appicon_name]))
         
@@ -100,6 +101,7 @@ module Fastlane
           filename += ".png"
 
           # downsize icon
+          # "!" resizes to exact size (needed for messages extension)
           image.resize "#{width}x#{height}!"
 
           # Don't write change/created times into the PNG properties
@@ -120,8 +122,8 @@ module Fastlane
             info['platform'] = 'ios'
           end
 
-          # if device is ios-marketing but we are generating messages extension app, set the idiom correctly
-          if icon['device'] == 'ios-marketing' && is_messages_extension
+          # if device is ios_marketing but we are generating messages extension app, set the idiom correctly
+          if icon['device'] == 'ios_marketing' && is_messages_extension
             info['platform'] = 'ios'
           end
           
@@ -195,7 +197,7 @@ module Fastlane
                                   optional: true,
                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :messages_extension,
-                                  env_name: "APPICON_MESSAGES",
+                                  env_name: "APPICON_MESSAGES_EXTENSION",
                              default_value: false,
                                description: "App icon is generated for Messages extension",
                                   optional: true,

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -42,14 +42,38 @@ module Fastlane
         }
       end
 
+      def self.needed_icons_messages_extension
+        {
+          iphone: {
+            '2x' => ['60x45'],
+            '3x' => ['60x45']
+          },
+          ipad: {
+            '2x' => ['67x50', '74x55']
+          },
+          messages: {
+            '2x' => ['27x20', '32x24'],
+            '3x' => ['27x20', '32x24']
+          },
+          ios_marketing: {
+            '1x' => ['1024x768']
+          }
+        }
+      end
+
       def self.run(params)
         fname = params[:appicon_image_file]
         basename = File.basename(fname, File.extname(fname))
-        basepath = Pathname.new(File.join(params[:appicon_path], params[:appicon_name]))
-
+        is_messages_extension = params[:messages_extension]
+        basepath = Pathname.new(File.join(params[:appicon_path], is_messages_extension ? params[:appicon_messages_name] : params[:appicon_name]))
+        
         image = MiniMagick::Image.open(fname)
 
-        Helper::AppiconHelper.check_input_image_size(image, 1024)
+        if is_messages_extension
+          Helper::AppiconHelper.check_input_image_size(image, 1024, 768)
+        else
+          Helper::AppiconHelper.check_input_image_size(image, 1024, 1024)
+        end
 
         # Convert image to png
         image.format 'png'
@@ -65,7 +89,7 @@ module Fastlane
 
         images = []
 
-        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], self.needed_icons, false)
+        icons = Helper::AppiconHelper.get_needed_icons(params[:appicon_devices], is_messages_extension ? self.needed_icons_messages_extension : self.needed_icons, false)
         icons.each do |icon|
           width = icon['width']
           height = icon['height']
@@ -76,7 +100,7 @@ module Fastlane
           filename += ".png"
 
           # downsize icon
-          image.resize "#{width}x#{height}"
+          image.resize "#{width}x#{height}!"
 
           # Don't write change/created times into the PNG properties
           # so unchanged files don't have different hashes.
@@ -89,6 +113,18 @@ module Fastlane
             'filename' => filename,
             'scale' => icon['scale']
           }
+
+          # if device is messages, we need to set it to universal
+          if icon['device'] == 'messages'
+            info['idiom'] = 'universal'
+            info['platform'] = 'ios'
+          end
+
+          # if device is ios-marketing but we are generating messages extension app, set the idiom correctly
+          if icon['device'] == 'ios-marketing' && is_messages_extension
+            info['platform'] = 'ios'
+          end
+          
 
           unless icon['device'] == 'universal'
             info['size'] = icon['size']
@@ -146,10 +182,22 @@ module Fastlane
                                description: "Name of the appiconset inside the asset catalogue",
                                   optional: true,
                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :appicon_messages_name,
+                                  env_name: "APPICON_MESSAGES_NAME",
+                             default_value: 'AppIcon.stickersiconset',
+                               description: "Name of the appiconset inside the asset catalogue",
+                                  optional: true,
+                                      type: String),
           FastlaneCore::ConfigItem.new(key: :remove_alpha,
                                   env_name: "REMOVE_ALPHA",
                              default_value: false,
                                description: "Remove the alpha channel from generated PNG",
+                                  optional: true,
+                                      type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :messages_extension,
+                                  env_name: "APPICON_MESSAGES",
+                             default_value: false,
+                               description: "App icon is generated for Messages extension",
                                   optional: true,
                                       type: Boolean)
         ]

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -1,10 +1,10 @@
 module Fastlane
   module Helper
     class AppiconHelper
-      def self.check_input_image_size(image, size)
-        UI.user_error!("Minimum width of input image should be #{size}") if image.width < size
-        UI.user_error!("Minimum height of input image should be #{size}") if image.height < size
-        UI.user_error!("Input image should be square") if image.width != image.height
+      def self.check_input_image_size(image, width, height)
+        UI.user_error!("Minimum width of input image should be #{width}") if image.width < width
+        UI.user_error!("Minimum height of input image should be #{height}") if image.height < height
+        UI.user_error!("Input image should be square") if image.width / image.height != width / height
       end
 
       def self.get_needed_icons(devices, needed_icons, is_android = false, custom_sizes = {})


### PR DESCRIPTION
Hi, I added a an option for creating Messages (Stickerpack) App Icon from a 1024x768px image (as in #6)

I tried to not change the original setup and keep the new option in a similar manner.
Please review my changes and comment on necessary changes. 

Thank you.