### PR TITLE
Add minimagick_cli option to choose graphicsmagick or imagemagick

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,20 +2,16 @@
 Style/ClassCheck:
   EnforcedStyle: kind_of?
 
-# It's better to be more explicit about the type
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # specs sometimes have useless assignments, which is fine
 Lint/UselessAssignment:
   Exclude:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
@@ -27,7 +23,7 @@ Style/DoubleNegation:
   Enabled: false
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Cop supports --auto-correct.
@@ -79,7 +75,7 @@ Metrics/CyclomaticComplexity:
   Max: 17
 
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 370
 
 # Configuration parameters: CountKeywordArgs.
@@ -119,7 +115,7 @@ Lint/ParenthesesAsGroupedExpression:
 
 # This would reject is_ in front of methods
 # We use `is_supported?` everywhere already
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 # We allow the $

--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ This project is a [fastlane](https://github.com/fastlane/fastlane) plugin. To ge
 fastlane add_plugin appicon
 ```
 
-Please note that this plugin uses the ImageMagick library. If you do not have it, you can install it via Homebrew:
 
+Please note that this plugin uses either GraphicsMagick or ImageMagick library. If you do not have either, you can install it via Homebrew:
+
+
+```
+brew install GraphicsMagick
+```
+or
 ```
 brew install ImageMagick
 ```
-
+The default cli for `minimagic` is set to `GraphicsMagick`, if you want to use `ImageMagick` instead, set the `minimagick_cli` option to `imagemagick` or set it to `auto` so `minimagick` will choose what's available.
 ## About appicon
 
 Generate required icon sizes and iconset from a master application icon.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This project is a [fastlane](https://github.com/fastlane/fastlane) plugin. To ge
 fastlane add_plugin appicon
 ```
 
-Please note that this plugin uses the GraphicsMagick library. If you do not have it, you can install it via Homebrew:
+Please note that this plugin uses the ImageMagick library. If you do not have it, you can install it via Homebrew:
 
 ```
-brew install graphicsmagick
+brew install ImageMagick
 ```
 
 ## About appicon
@@ -115,7 +115,7 @@ If you have trouble using plugins, check out the [Plugins Troubleshooting](https
 
 ## Using `fastlane` Plugins
 
-For more information about how the `fastlane` plugin system works, check out the [Plugins documentation](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md).
+For more information about how the `fastlane` plugin system works, check out the [Plugins documentation](https://docs.fastlane.tools/plugins/create-plugin/).
 
 ## About `fastlane`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ or
 ```
 brew install imagemagick
 ```
-The default cli for the `mini_magic` gem is set to `GraphicsMagick`. If you want to use `ImageMagick` instead, set the `minimagick_cli` option in to `imagemagick` or set it to `auto` so `minimagick` will choose what's available.
+
+The default CLI for the `mini_magick` gem is set to auto pick. It will first try to use `GraphicsMagick` (if you have it installed) otherwise it will use `ImageMagick`. If you want to be explicit about which CLI you use, set the `minimagick_cli` option to `graphicsmagick` or `imagemagick`. Not specifying this option will set `MiniMagick` to use auto which will choose what's available.
+
 ## About appicon
 
 Generate required icon sizes and iconset from a master application icon.

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ fastlane add_plugin appicon
 ```
 
 
-Please note that this plugin uses either GraphicsMagick or ImageMagick library. If you do not have either, you can install it via Homebrew:
+Please note that this plugin uses [minimagick](https://github.com/minimagick/minimagick), which requires either GraphicsMagick or ImageMagick library. If you have neither, you can install either via Homebrew:
 
 
 ```
-brew install GraphicsMagick
+brew install graphicsmagick
 ```
 or
 ```
-brew install ImageMagick
+brew install imagemagick
 ```
-The default cli for `minimagic` is set to `GraphicsMagick`, if you want to use `ImageMagick` instead, set the `minimagick_cli` option to `imagemagick` or set it to `auto` so `minimagick` will choose what's available.
+The default cli for the `mini_magic` gem is set to `GraphicsMagick`. If you want to use `ImageMagick` instead, set the `minimagick_cli` option in to `imagemagick` or set it to `auto` so `minimagick` will choose what's available.
 ## About appicon
 
 Generate required icon sizes and iconset from a master application icon.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,7 @@ end
 lane :ios_messages_extension do
   appicon(
     appicon_image_file: 'spec/fixtures/ThemojiSplash.png',
-    appicon_devices: [:iphone, :ipad, :ios_marketing, :messages],
+    appicon_devices: %i[iphone ipad ios_marketing messages],
     appicon_path: 'app/iMessageStickers/Stickers.xcassets',
     messages_extension: true
   )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 lane :ios do
   appicon(
     appicon_image_file: 'spec/fixtures/Themoji.png',
-    appicon_devices: [:ipad, :iphone, :ios_marketing, :watch, :watch_marketing],
+    appicon_devices: %i[ipad iphone ios_marketing watch watch_marketing],
     appicon_path: 'app'
   )
 end
@@ -26,8 +28,8 @@ end
 lane :android_splash do
   android_appicon(
     appicon_image_file: 'spec/fixtures/ThemojiSplash.png',
-    appicon_icon_types: [:splash_port, :splash_land],
+    appicon_icon_types: %i[splash_port splash_land],
     appicon_path: 'app/res/drawable',
     appicon_filename: 'splash'
-  ) 
+  )
 end

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -174,10 +174,14 @@ module Fastlane
                              default_value: false,
                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :minimagick_cli,
-                               description: "Set minimagick cli, defaults to graphicsmagick",
-                             default_value: "graphicsmagick",
+                                  env_name: "APPICON_MINIMAGICK_CLI",
+                               description: "Set MiniMagick CLI (auto picked by default). Values are: graphicsmagick, imagemagick",
                                   optional: true,
-                                      type: String)
+                                      type: String,
+                              verify_block: proc do |value|
+                                        av = %w(graphicsmagick imagemagick)
+                                        UI.user_error!("Unsupported minimagick cli '#{value}', must be: #{av}") unless av.include?(value)
+                                      end)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -43,10 +43,7 @@ module Fastlane
 
       def self.run(params)
 
-        MiniMagick.configure do |config|
-          config.cli = params[:use_imagemagick] ? :imagemagick : :graphicsmagick
-          config.timeout = 5
-        end
+        Helper::AppiconHelper.set_cli(params[:minimagick_cli])
 
         fname = params[:appicon_image_file]
         custom_sizes = params[:appicon_custom_sizes]
@@ -176,11 +173,11 @@ module Fastlane
                                description: "Generate round icons?",
                              default_value: false,
                                       type: Boolean),
-          FastlaneCore::ConfigItem.new(key: :use_imagemagick,
-                               description: "Use imagemagick as cli instead of graphicsmagic?",
-                             default_value: false,
+          FastlaneCore::ConfigItem.new(key: :minimagick_cli,
+                               description: "Set minimagick cli, defaults to graphicsmagick",
+                             default_value: "graphicsmagick",
                                   optional: true,
-                                      type: Boolean)
+                                      type: String)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -42,6 +42,12 @@ module Fastlane
       end
 
       def self.run(params)
+
+        MiniMagick.configure do |config|
+          config.cli = params[:use_imagemagick] ? :imagemagick : :graphicsmagick
+          config.timeout = 5
+        end
+
         fname = params[:appicon_image_file]
         custom_sizes = params[:appicon_custom_sizes]
 
@@ -169,6 +175,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :generate_rounded,
                                description: "Generate round icons?",
                              default_value: false,
+                                      type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :use_imagemagick,
+                               description: "Use imagemagick as cli instead of graphicsmagic?",
+                             default_value: false,
+                                  optional: true,
                                       type: Boolean)
         ]
       end

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -209,10 +209,14 @@ module Fastlane
                                   optional: true,
                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :minimagick_cli,
-                               description: "Set minimagick cli, defaults to graphicsmagick",
-                             default_value: "graphicsmagick",
+                                  env_name: "APPICON_MINIMAGICK_CLI",
+                               description: "Set MiniMagick CLI (auto picked by default). Values are: graphicsmagick, imagemagick",
                                   optional: true,
-                                      type: String)
+                                      type: String,
+                              verify_block: proc do |value|
+                                        av = %w(graphicsmagick imagemagick)
+                                        UI.user_error!("Unsupported minimagick cli '#{value}', must be: #{av}") unless av.include?(value)
+                                      end)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -47,10 +47,7 @@ module Fastlane
         basename = File.basename(fname, File.extname(fname))
         basepath = Pathname.new(File.join(params[:appicon_path], params[:appicon_name]))
 
-        MiniMagick.configure do |config|
-          config.cli = params[:use_imagemagick] ? :imagemagick : :graphicsmagick
-          config.timeout = 5
-        end
+        Helper::AppiconHelper.set_cli(params[:minimagick_cli])
 
         image = MiniMagick::Image.open(fname)
 
@@ -157,11 +154,11 @@ module Fastlane
                                description: "Remove the alpha channel from generated PNG",
                                   optional: true,
                                       type: Boolean),
-          FastlaneCore::ConfigItem.new(key: :use_imagemagick,
-                               description: "Use imagemagick as cli instead of graphicsmagic?",
-                             default_value: false,
+          FastlaneCore::ConfigItem.new(key: :minimagick_cli,
+                               description: "Set minimagick cli, defaults to graphicsmagick",
+                             default_value: "graphicsmagick",
                                   optional: true,
-                                      type: Boolean)
+                                      type: String)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -47,6 +47,11 @@ module Fastlane
         basename = File.basename(fname, File.extname(fname))
         basepath = Pathname.new(File.join(params[:appicon_path], params[:appicon_name]))
 
+        MiniMagick.configure do |config|
+          config.cli = params[:use_imagemagick] ? :imagemagick : :graphicsmagick
+          config.timeout = 5
+        end
+
         image = MiniMagick::Image.open(fname)
 
         Helper::AppiconHelper.check_input_image_size(image, 1024)
@@ -150,6 +155,11 @@ module Fastlane
                                   env_name: "REMOVE_ALPHA",
                              default_value: false,
                                description: "Remove the alpha channel from generated PNG",
+                                  optional: true,
+                                      type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :use_imagemagick,
+                               description: "Use imagemagick as cli instead of graphicsmagic?",
+                             default_value: false,
                                   optional: true,
                                       type: Boolean)
         ]

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -1,3 +1,5 @@
+require 'mini_magick'
+
 module Fastlane
   module Helper
     class AppiconHelper
@@ -5,6 +7,20 @@ module Fastlane
         UI.user_error!("Minimum width of input image should be #{size}") if image.width < size
         UI.user_error!("Minimum height of input image should be #{size}") if image.height < size
         UI.user_error!("Input image should be square") if image.width != image.height
+      end
+
+      def self.set_cli(minimagick_cli)
+        MiniMagick.configure do |config|
+          case minimagick_cli
+          when "auto"
+            config.cli = MiniMagick.cli()
+          when "graphicsmagick"
+          config.cli = :graphicsmagick
+          when "imagemagick"
+            config.cli = :imagemagick
+          end
+          config.timeout = 5
+        end
       end
 
       def self.get_needed_icons(devices, needed_icons, is_android = false, custom_sizes = {})

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -12,12 +12,12 @@ module Fastlane
       def self.set_cli(minimagick_cli)
         MiniMagick.configure do |config|
           case minimagick_cli
-          when "auto"
-            config.cli = MiniMagick.cli()
           when "graphicsmagick"
           config.cli = :graphicsmagick
           when "imagemagick"
             config.cli = :imagemagick
+          else
+            config.cli = MiniMagick.cli()
           end
           config.timeout = 5
         end


### PR DESCRIPTION
Added minimagick_cli param. By default, the image lib remains graphicsmagick, as I didn't want to brake any releases. 

I did not compare the image outputs of the two cli's directly. 

I'm still not sure why graphicsmagick is the deafault cli for the plugin, as [minimagic's default cli should be imagemagick](https://github.com/minimagick/minimagick#switching-clis-imagemagick--graphicsmagick). If I uninstall graphicsmagick, it still tries to call `gm identify ...`. 

Still, using imagemagick should results in a faster build time on Bitrise, or any other CI/CD solution, which has imagemagick preinstalled, because you'd no longer have to install graphicsmagic.

Let me now what needs changing, I'm quite new to Ruby. 

- Updated .rubocop.yml as suggested by running `rake`
- Updated Fastfile as suggested by running `rake`
- Added minimagick_cli optional param, which can be 'graphicsmagick', 'imagemagick', 'auto'. Default to 'graphicsmagick'